### PR TITLE
Fix the version on README not matching the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Make barcode views with ease in Jetpack Compose.
 Gradle users:
 
 ```
-implementation("com.simonsickle:composed-barcodes:1.1.1")
+implementation("com.simonsickle:composed-barcodes:1.3.0")
 ```
 
 Examples


### PR DESCRIPTION
Helps people avoid using an outdated version by mistake. Replacing it with `<latest-version>` would also be helpful.